### PR TITLE
Feat: Add Dockerfile for testing install.sh script on Ubuntu 24.04 (#1)

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:24.04
+WORKDIR /app
+
+COPY install.sh /app/install.sh
+RUN apt-get update && \
+    apt-get install -y sudo wget unzip dos2unix && \
+    apt-get clean
+
+
+RUN dos2unix /app/install.sh
+
+RUN chmod +x /app/install.sh
+
+CMD ["./install.sh"]


### PR DESCRIPTION
Closes #1 

This commit introduces a Dockerfile to facilitate testing the install.sh script in a controlled **Ubuntu 24.04** environment. 
These changes ensure that the `install.sh` script can be tested in a consistent environment, avoiding issues related to different host system configurations.

# Setup Instructions:
### Build the Docker Image:
```bash
docker build -t xui .
```
### Run the Docker Container:
```bash
docker run -it --name xuitest xui
```

# Result:
![2024-11-11 (1)](https://github.com/user-attachments/assets/e533964e-c5ba-4db8-ae31-08df0e4d6a4d)
![2024-11-11](https://github.com/user-attachments/assets/f1cf4f86-a650-4e2e-ad43-1cd98a3e56b7)

Please let me know if you want to change or add anything to the PR. Also, I will be glad to add the Docker documentation to `README.md.`, Or publish the Docker image into [dockerhub](https://hub.docker.com/search). Just raise the issue and assign me.

Cheers 🥂
Have a great day!